### PR TITLE
Fix actions after transferring to new organization

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,5 +1,5 @@
 name: Dependabot auto-approve
-on: pull_request_target
+on: pull_request
 
 permissions:
   pull-requests: write
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,14 +1,14 @@
 name: Lint Golang Codebase
 
 on:
-  pull_request_target:
+  pull_request:
     paths-ignore:
     - 'docs/**'
     - '**/*.md'
 jobs:
   golangci:
     name: lint
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,14 +12,14 @@ on:
     paths-ignore:
     - 'docs/**'
     - '**/*.md'
-  pull_request_target:
+  pull_request:
     paths-ignore:
     - 'docs/**'
     - '**/*.md'
 
 jobs:
   buildAndPush:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -43,7 +43,7 @@ jobs:
       with:
         image: tonistiigi/binfmt:latest
         platforms: ${{env.platforms}}
-    # workaround for self-hosted runner
+    # workaround for ubuntu-latest runner
     # https://github.com/mumoshu/actions-runner-controller-ci/commit/e91c8c0f6ca82aa7618010c6d2f417aa46c4a4bf
     - name: Set up Docker Context for Buildx
       id: buildx-context
@@ -54,9 +54,9 @@ jobs:
       uses: docker/setup-buildx-action@v3
       with:
         version: latest
-        endpoint: builders # self-hosted
+        endpoint: builders # ubuntu-latest
     - name: Login to GHCR
-      if: github.event_name != 'pull_request_target'
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -68,7 +68,7 @@ jobs:
       with:
         context: .
         platforms: ${{env.platforms}}
-        push: ${{ github.event_name != 'pull_request_target' }}
+        push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         secrets: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
     - main
-  pull_request_target:
+  pull_request:
 
 jobs:
   update_release_draft:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - uses: release-drafter/release-drafter@v6
       with:

--- a/.github/workflows/size-labels.yaml
+++ b/.github/workflows/size-labels.yaml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: size-label
         uses: pascalgn/size-label-action@v0.5.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'deploy/**'
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths-ignore:
@@ -20,7 +20,7 @@ on:
 
 jobs:
   run:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
- run on public runners only
- use `pull_request` as an event trigger

