### PR TITLE
Fix netdata naming

### DIFF
--- a/config/default/clusterrb.yaml
+++ b/config/default/clusterrb.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: sa-clusterrolebinding
+  name: rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -10,6 +10,7 @@ bases:
 - netdatadeployment.yaml
 - rbac.yaml
 - clusterrb.yaml
+- service_account.yaml
 
 configMapGenerator:
 - name: config

--- a/config/default/netdatadeployment.yaml
+++ b/config/default/netdatadeployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   annotations:
     configmap.reloader.stakater.com/reload: "config"
-  name: netdata
+  name: controller
 spec:
   replicas: 1
   selector:

--- a/config/default/rbac.yaml
+++ b/config/default/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: netdata-role
+  name: role
 rules:
   - apiGroups:
       - ipam.onmetal.de

--- a/config/default/service_account.yaml
+++ b/config/default/service_account.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: netdata-sa
+  name: sa


### PR DESCRIPTION
Use prefix and generic names, so we get resource names like `netdata-controller`, `netdata-sa`, `netdata-role`, etc.

